### PR TITLE
Add a link to the documentation in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # direct2d-rs [![Crates.io](https://img.shields.io/crates/v/direct2d.svg)](https://crates.io/crates/direct2d)
 
+[Documentation](https://docs.rs/direct2d/*/direct2d/)
+
 Safe abstractions for drawing on Windows using Direct2D
 
 To use it, add this to your Cargo.toml:


### PR DESCRIPTION
Hi!  Thank you for creating this nice crate.

I frequently refer to the documentation on docs.rs, which is linked-to from the project's crates.io page, so I thought it might be useful to link to it directly from the README like some other projects do (e.g. [winapi-rs](https://github.com/retep998/winapi-rs/blob/0.3/README.md)).
